### PR TITLE
Fix integration tests

### DIFF
--- a/library/Zend/Db/Statement.php
+++ b/library/Zend/Db/Statement.php
@@ -209,6 +209,12 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         // remove "foo\"bar"
         $sql = preg_replace("/\"(\\\\\"|[^\"])*\"/Us", '', $sql);
 
+        if ($sql === null) {
+            // this preg_replace call can return NULL in case of error (PREG_BACKTRACK_LIMIT_ERROR).
+            // In this case the result of this method will be an empty string.
+            return '';
+        }
+        
         // get the character for delimited id quotes,
         // this is usually " but in MySQL is `
         $d = $this->_adapter->quoteIdentifier('a');


### PR DESCRIPTION
Test: \Magento\Framework\Backup\DbTest::testBackupAndRollbackIncludesCustomTriggers  

Error:
Unable to revert fixture: Magento/Framework/Backup/_files/trigger.php #0 /var/www/html/dev/tests/integration/testsuite/Magento/Framework/Backup/DbTest.php(42): Magento\Framework\Backup\DbTest->testBackupAndRollbackIncludesCustomTriggers()


#### related PRs
* https://github.com/mage-os/mageos-magento2/pull/61